### PR TITLE
Addition of a 'wrap_text' method

### DIFF
--- a/spec/tallboy/style_spec.cr
+++ b/spec/tallboy/style_spec.cr
@@ -30,19 +30,19 @@ describe Tallboy::Style do
       style.charset.row.to_tuple.should eq({"x", "x", "x", "x"})
     end
   end
+end
 
-  describe "CharSetting" do
-    style = Tallboy::Style.new
+describe "CharSetting" do
+  style = Tallboy::Style.new
 
-    it "getters returns defaults" do
-      style.charset.separator.left.should eq("+")
-      style.charset.separator.pad.should eq("-")
-      style.charset.separator.mid.should eq("+")
-      style.charset.separator.right.should eq("+")
-    end
+  it "getters returns defaults" do
+    style.charset.separator.left.should eq("+")
+    style.charset.separator.pad.should eq("-")
+    style.charset.separator.mid.should eq("+")
+    style.charset.separator.right.should eq("+")
+  end
 
-    it "to_tuple returns character setting" do
-      style.charset.separator.to_tuple.should eq({"+", "-", "+", "+"})
-    end
+  it "to_tuple returns character setting" do
+    style.charset.separator.to_tuple.should eq({"+", "-", "+", "+"})
   end
 end

--- a/src/tallboy/cell.cr
+++ b/src/tallboy/cell.cr
@@ -57,7 +57,7 @@ module Tallboy
         end
       when :word
         if max_line_size > 0
-          words = @data.to_s.split(" ")
+          words = @data.to_s.gsub(/(\ |\n|\t){1,}/, " ").split(" ")
           wrapped_data = ""
 
           row_size = 0

--- a/src/tallboy/cell.cr
+++ b/src/tallboy/cell.cr
@@ -45,5 +45,39 @@ module Tallboy
     def line_exists?(line_num)
       line_num < lines.size
     end
+
+    def wrap_text(wrap_by : Symbol, max_line_size : Int32)
+      case wrap_by
+      when :char
+        if max_line_size > 0
+          chars = @data.to_s.chars
+          wrapped_data = ""
+          chars.each_slice(max_line_size) { |slice| wrapped_data += slice.join("") + "\n" }
+          @data = wrapped_data.chomp("\n")
+        end
+      when :word
+        if max_line_size > 0
+          words = @data.to_s.split(" ")
+          wrapped_data = ""
+
+          row_size = 0
+          words.each do |w|
+            raise "Word wrapping failed, '#{w}' is bigger than max line size" if w.size > max_line_size
+            row_size += w.size
+            if row_size < max_line_size
+              wrapped_data += "#{w} "
+            else
+              wrapped_data += "\n#{w} "
+              row_size = 0
+            end
+          end
+
+          @data = wrapped_data.chomp(" ")
+        end
+      else
+        raise "Unknown wrapping type, use ':char' or ':word'"
+      end
+    end
   end
 end
+

--- a/src/tallboy/cell.cr
+++ b/src/tallboy/cell.cr
@@ -35,7 +35,7 @@ module Tallboy
         str.rjust(width, char)
       when .center?
         str
-          .rjust(width / 2 + str.size / 2 + 1, char)
+          .rjust((width / 2 + str.size / 2 + 1).to_i, char)
           .ljust(width, char)
       else
         str.ljust(width, char)

--- a/src/tallboy/cell.cr
+++ b/src/tallboy/cell.cr
@@ -62,7 +62,7 @@ module Tallboy
 
           row_size = 0
           words.each do |w|
-            raise "Word wrapping failed, '#{w}' is bigger than max line size" if w.size > max_line_size
+            raise "Word wrapping failed, '#{w}' (#{w.size}) is bigger than max line size (#{max_line_size})" if w.size > max_line_size
             row_size += w.size
             if row_size < max_line_size
               wrapped_data += "#{w} "
@@ -80,4 +80,3 @@ module Tallboy
     end
   end
 end
-

--- a/src/tallboy/column.cr
+++ b/src/tallboy/column.cr
@@ -1,5 +1,4 @@
 module Tallboy
-
   class Column
     @cells : Array(Cell)
     include Enumerable(Cell)
@@ -12,17 +11,20 @@ module Tallboy
       cells.each do |cell|
         yield(cell)
       end
-    end 
-    
+    end
+
     def align=(align : Align)
       align(align)
     end
-    
+
     def align(align : Align)
       cells.each do |cell|
         cell.align = align
       end
     end
-  end
 
+    def wrap_text(wrap_by : Symbol, max_line_size : Int32)
+      @cells.each { |cell| cell.wrap_text(wrap_by, max_line_size) }
+    end
+  end
 end

--- a/src/tallboy/table.cr
+++ b/src/tallboy/table.cr
@@ -80,5 +80,11 @@ module Tallboy
     private def max_elem_size(arr)
       arr.map(&.size).max
     end
+
+    def wrap_text(wrap_by : Symbol, max_line_size : Int32)
+      @rows.each do |row|
+        row.cells.each { |cell| cell.wrap_text(wrap_by, max_line_size) }
+      end
+    end
   end
 end

--- a/src/tallboy/table.cr
+++ b/src/tallboy/table.cr
@@ -78,7 +78,7 @@ module Tallboy
     end
 
     private def max_elem_size(arr)
-      arr.map(&.size).max
+      arr.map(&.size).max.to_i
     end
 
     def wrap_text(wrap_by : Symbol, max_line_size : Int32)


### PR DESCRIPTION
Hi, 
It's just a small improvement on the already nice visualization.

Usage is quite simple (and adheres to the current syntax):
```
data = [
  ["foo","bar","foo bar"],
  ["d","e","f"]
]

table = Tallboy::Table.new(data)

# Wrap whole table by words:
table.wrap_text(:word, 3)
puts table.render(row_separator: true)

# output => 
+-----+-----+------+
|     |     |      |
| foo | bar | foo  |
|     |     | bar  |
+-----+-----+------+
| d   | e   | f    |
+-----+-----+------+

# Wrap column by chars:
table.column(2).wrap_text(:char, 2)
puts table.render(row_separator: true)

# output => 
+-----+-----+----+
| foo | bar | fo |
|     |     | o  |
|     |     | ba |
|     |     | r  |
+-----+-----+----+
| d   | e   | f  |
+-----+-----+----+


